### PR TITLE
Add export for ROUTINE_PROMISE_ACTION action type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 import routinePromiseWatcherSaga from './routinePromiseWatcherSaga';
 import bindRoutineToReduxForm from './bindRoutineToReduxForm';
 import createRoutine from './createRoutine';
+import { ROUTINE_PROMISE_ACTION } from './constants';
 
-export { routinePromiseWatcherSaga, bindRoutineToReduxForm, createRoutine };
+export {
+  routinePromiseWatcherSaga,
+  bindRoutineToReduxForm,
+  createRoutine,
+  ROUTINE_PROMISE_ACTION,
+};

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,12 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
-import { createRoutine, bindRoutineToReduxForm, routinePromiseWatcherSaga } from '../src';
+import {
+  createRoutine,
+  bindRoutineToReduxForm,
+  routinePromiseWatcherSaga,
+  ROUTINE_PROMISE_ACTION,
+ } from '../src';
 
 describe('Redux saga routines', () => {
   it('should export createRoutine function', () => {
@@ -15,5 +20,9 @@ describe('Redux saga routines', () => {
 
   it('should export routinePromiseWatcherSaga function', () => {
     expect(routinePromiseWatcherSaga).to.be.ok;
+  });
+
+  it('should export ROUTINE_PROMISE_ACTION action type', () => {
+    expect(ROUTINE_PROMISE_ACTION).to.be.ok;
   });
 });


### PR DESCRIPTION
To use in some custom actions, reducers, middleware  etc.

For example my use case is to have routine to promise converter using [redux-thunk](https://github.com/gaearon/redux-thunk).

```javascript
// import { ROUTINE_PROMISE_ACTION }  from 'redux-saga-routines' <== missing export
const ROUTINE_PROMISE_ACTION = '@@redux-saga-routines/PROMISE'

export default function routineToPromiseAction (routine) {
  return (payload) => (dispatch) => new Promise((resolve, reject) => dispatch({
    type: ROUTINE_PROMISE_ACTION,
    payload: {
      payload,
      routine,
      defer: { resolve, reject },
    },
  }))
}
```

