### PR TITLE
Add new redux saga version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "eslint": "^2.4.0",
     "eslint-plugin-babel": "^3.0.0",
     "mocha": "^2.3.4",
-    "redux-saga": "^0.15.0",
+    "redux-saga": "^0.15.0 || ^0.16.0",
     "rimraf": "^2.5.4",
     "sinon": "^2.1.0"
   },
   "peerDependencies": {
-    "redux-saga": "^0.15.0"
+    "redux-saga": "^0.15.0 || ^0.16.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes peer dependencies errors when using `redux-saga` version `0.16.0`.