### PR TITLE
Add support of recursive reducerMap in handleActions

### DIFF
--- a/src/createRoutine.js
+++ b/src/createRoutine.js
@@ -4,7 +4,7 @@ import routineStages from './routineStages';
 export default function createRoutine(typePrefix, ...params) {
   const createActionCreator = (type) => createAction(`${typePrefix}/${type}`, ...params);
 
-  return routineStages.reduce(
+  const action = routineStages.reduce(
     (result, stage) => {
       const actionCreator = createActionCreator(stage);
       return Object.assign(result, {
@@ -14,4 +14,9 @@ export default function createRoutine(typePrefix, ...params) {
     },
     createActionCreator(routineStages[0])
   );
+
+  // allow to use this action in recursive structure in `handleActions`
+  action.toString = () => typePrefix;
+
+  return action;
 }

--- a/test/createRoutine.js
+++ b/test/createRoutine.js
@@ -43,7 +43,7 @@ describe('createRoutine', () => {
     const routine = createRoutine(PREFIX);
 
     expect(routine).to.be.a('function');
-    expect(routine.toString()).to.equal(TRIGGER);
+    expect(routine.toString()).to.equal(PREFIX);
     expect(routine(payload)).to.deep.equal(triggerAction);
 
     expect(routine.trigger).to.be.a('function');
@@ -100,7 +100,7 @@ describe('createRoutine', () => {
     };
 
     expect(routine).to.be.a('function');
-    expect(routine.toString()).to.equal(TRIGGER);
+    expect(routine.toString()).to.equal(PREFIX);
     expect(routine(originalPayload)).to.deep.equal(triggerAction);
 
     expect(routine.trigger).to.be.a('function');
@@ -164,7 +164,7 @@ describe('createRoutine', () => {
     };
 
     expect(routine).to.be.a('function');
-    expect(routine.toString()).to.equal(TRIGGER);
+    expect(routine.toString()).to.equal(PREFIX);
     expect(routine(payload)).to.deep.equal(triggerAction);
 
     expect(routine.trigger).to.be.a('function');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,20 @@
 # yarn lockfile v1
 
 
+"@types/react@*":
+  version "16.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.38.tgz#76617433ea10274505f60bb86eddfdd0476ffdc2"
+
 "@types/redux-actions@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@types/redux-actions/-/redux-actions-2.2.2.tgz#e9d488c83ce1244178956cb0580a5aec3349eb4f"
+
+"@types/redux-form@^7.0.6":
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/@types/redux-form/-/redux-form-7.0.14.tgz#1bd23434647af8d8d387c24fc9b61eec0276cb2c"
+  dependencies:
+    "@types/react" "*"
+    redux "^3.6.0"
 
 abbrev@1:
   version "1.1.1"
@@ -1660,15 +1671,23 @@ lodash-es@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
+lodash-es@^4.2.1:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.5.tgz#9fc6e737b1c4d151d8f9cae2247305d552ce748f"
+
 lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.2.1:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2018,6 +2037,15 @@ redux-saga@^0.15.0:
   version "0.15.6"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.15.6.tgz#8638dc522de6c6c0a496fe8b2b5466287ac2dc4d"
 
+redux@^3.6.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
@@ -2290,6 +2318,10 @@ supports-color@1.2.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+symbol-observable@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@^3.7.8:
   version "3.8.3"


### PR DESCRIPTION
`reducerMap` in `handleActions ` could have recursive structure, like

```
export default handleActions({
  [loginRoutine]: {
    SUCCESS: (state) => { ...state },
    FAILURE: (state) => { ...state }
  }
})
```
But doing so is impossible, because `loginRoutine.toString()` returns not PREFIX, but PREFIX/TRIGGER.

This pull request fixes this.