### PR TITLE
Pass submission result to redux-form submit handler

### DIFF
--- a/src/routinePromiseWatcherSaga.js
+++ b/src/routinePromiseWatcherSaga.js
@@ -25,7 +25,7 @@ export function* handleRoutinePromiseAction(action) {
   ]);
 
   if (success) {
-    yield reduxFormCompatible ? call(resolve) : call(resolve, getPayload(success));
+    yield call(resolve, getPayload(success));
   } else {
     yield call(reject, getPayload(failure));
   }


### PR DESCRIPTION
Redux form can handle submission results returned by `onSubmit` handler, for example, https://redux-form.com/7.2.3/docs/api/reduxform.md/#-code-onsubmitsuccess-function-code-optional-

These changes propose passing a submission results to `onSubmit` handler